### PR TITLE
First version to sign PDF documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+coverage

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Soluti PHP sdk
+
+Its a simple SDK for PHP language that abstract Soluti's digital signature service. In the first moment is possible to sign PDF documents authenticating using _OAuth_ or _Basic Credentials_
+
+## Installation
+
+```bash
+composer require "memeddev/soluti-sdk-php=*"
+```
+
+## Basic Usage
+
+```php
+use Memed\Soluti\Auth\Client;
+use Memed\Soluti\Auth\Credentials;
+use Memed\Soluti\Auth\Token;
+use Memed\Soluti\Config;
+use Memed\Soluti\Document;
+use Memed\Soluti\Manager;
+use Memed\Soluti\Signer;
+use GuzzleHttp\Client as GuzzleClient;
+
+// -----------------------
+// Authentication strategy
+// -----------------------
+
+// Using Credentials
+$token = new Credentials(
+    new Client('CLIENT_ID', 'CLIENT_SECRET'),
+    'USERNAME',
+    'PASSWORD',
+    60 // How much longer token will be acceptable after authentication (in seconds)
+);
+
+// Using OAuth token
+$token = new Token('some-secret-oauth-token', 'bearer');
+
+// -----------------------
+// Document signature
+// -----------------------
+ 
+// Defines base URL's
+$config = new Config([
+    'url_cess' => 'http://cess:8080',
+    'url_vaultid' => 'https://apicloudid.hom.vaultid.com.br/oauth',
+]);
+
+// Initializes signer service
+$manager = new Manager($config, new Client(new GuzzleClient());
+$signer = new Signer($manager);
+
+// Creates a document instance using file which you want to sign.
+$document = new Document(__DIR__.'/file_to_sign.pdf');
+
+// Defines directory to save signed documents.
+$destinationDir = '/some/directory';
+
+// Signs document
+$files = $signer->sign($document, $token, $destinationDir);
+
+// Result
+// array(1) {
+//   [0] =>
+//   string(32) "/some/directory/signed_file.pdf"
+// }
+```

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
         "psr-4": {
             "Memed\\Soluti\\": "src/Memed/Soluti"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Memed\\Soluti\\": "tests/Memed/Soluti"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,12 @@
     "license": "MIT",
     "type": "library",
     "require": {
-        "php": ">=7.2"
+        "php": ">=7.2",
+        "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.3"
+        "phpunit/phpunit": "^8.3",
+        "mockery/mockery": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,12 @@
     "description": "SDK for Soluti's digital signature",
     "keywords": ["soluti", "sdk", "digital signature"],
     "license": "MIT",
-    "type": "project",
+    "type": "library",
     "require": {
         "php": ">=7.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,14 @@
     },
     "autoload": {
         "psr-4": {
-            "Memed\\Soluti\\": "src/Memed/Soluti"
+            "\\Memed\\Soluti\\": "src/Memed/Soluti"
+        }
+    },
+    "extra": {
+        "extra": {
+            "branch-alias": {
+                "dev-master": "0.1.x-dev"
+            }
         }
     },
     "autoload-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="unit">
+            <directory suffix="Test.php">tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,4 +14,9 @@
             <directory suffix="Test.php">tests/</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Memed/Soluti/Auth/AuthStrategy.php
+++ b/src/Memed/Soluti/Auth/AuthStrategy.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Auth;
+
+/**
+ * This is a dummy interface with no methods which has the objective to abstract
+ * signature authentication strategies:
+ *   1. Backend authentication: when you already have username and password or;
+ *   2. Frontend authentication: when you need to ask credentials to receive
+ *      token before start transactions.
+ */
+interface AuthStrategy
+{
+}

--- a/src/Memed/Soluti/Auth/Client.php
+++ b/src/Memed/Soluti/Auth/Client.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Auth;
+
+class Client
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $secret;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(string $id, string $secret)
+    {
+        $this->id = $id;
+        $this->secret = $secret;
+    }
+
+    /**
+     * Retrieves client id.
+     */
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * Retrieves client secret.
+     */
+    public function secret(): string
+    {
+        return $this->secret;
+    }
+}

--- a/src/Memed/Soluti/Auth/Credentials.php
+++ b/src/Memed/Soluti/Auth/Credentials.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Auth;
+
+/**
+ * This class is a simple DTO to handle user's credentials.
+ */
+class Credentials
+{
+    /**
+     * @var string
+     */
+    protected $username;
+
+    /**
+     * @var string
+     */
+    protected $password;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(string $username, string $password)
+    {
+        $this->username = $username;
+        $this->password = $password;
+    }
+
+    /**
+     * Retrieves username.
+     */
+    public function username(): string
+    {
+        return $this->username;
+    }
+
+    /**
+     * Retrieves password.
+     */
+    public function password(): string
+    {
+        return $this->password;
+    }
+}

--- a/src/Memed/Soluti/Auth/Credentials.php
+++ b/src/Memed/Soluti/Auth/Credentials.php
@@ -7,8 +7,13 @@ namespace Memed\Soluti\Auth;
 /**
  * This class is a simple DTO to handle user's credentials.
  */
-class Credentials
+class Credentials implements AuthStrategy
 {
+    /**
+     * @var Client
+     */
+    protected $client;
+
     /**
      * @var string
      */
@@ -20,12 +25,32 @@ class Credentials
     protected $password;
 
     /**
+     * @var int
+     */
+    protected $ttl;
+
+    /**
      * Constructor.
      */
-    public function __construct(string $username, string $password)
-    {
+    public function __construct(
+        Client $client,
+        string $username,
+        string $password,
+        int $ttl
+    ) {
+        $this->client = $client;
         $this->username = $username;
         $this->password = $password;
+        $this->ttl = $ttl;
+    }
+
+    /**
+     * Retrieves client.
+     * @return [type] [description]
+     */
+    public function client(): Client
+    {
+        return $this->client;
     }
 
     /**
@@ -42,5 +67,13 @@ class Credentials
     public function password(): string
     {
         return $this->password;
+    }
+
+    /**
+     * Retrieves time (in seconds) that credentials will be valid.
+     */
+    public function ttl(): int
+    {
+        return $this->ttl;
     }
 }

--- a/src/Memed/Soluti/Auth/Session.php
+++ b/src/Memed/Soluti/Auth/Session.php
@@ -33,7 +33,7 @@ class Session
     {
         $request = new Request(
             'post',
-            'https://apicloudid.hom.vaultid.com.br/oauth',
+            $this->manager->vaultIdUrl('/oauth'),
             [
                 'client_id' => $credentials->client()->id(),
                 'client_secret' => $credentials->client()->secret(),

--- a/src/Memed/Soluti/Auth/Session.php
+++ b/src/Memed/Soluti/Auth/Session.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Memed\Soluti\Auth;
 
 use GuzzleHttp\Psr7\Response;
-use Memed\Soluti\Http\Client as HttpClient;
 use Memed\Soluti\Http\Request;
+use Memed\Soluti\Manager;
 
 /**
  * This class is responsible for handling session on Soluti's service.
@@ -14,16 +14,16 @@ use Memed\Soluti\Http\Request;
 class Session
 {
     /**
-     * @var Client
+     * @var Manager
      */
-    protected $client;
+    protected $manager;
 
     /**
      * Constructor.
      */
-    public function __construct(HttpClient $client)
+    public function __construct(Manager $manager)
     {
-        $this->client = $client;
+        $this->manager = $manager;
     }
 
     /**
@@ -45,7 +45,7 @@ class Session
             ]
         );
 
-        return $this->parseResponse($this->client->json($request));
+        return $this->parseResponse($this->manager->client()->json($request));
     }
 
     /**

--- a/src/Memed/Soluti/Auth/Session.php
+++ b/src/Memed/Soluti/Auth/Session.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Auth;
+
+use GuzzleHttp\Psr7\Response;
+use Memed\Soluti\Http\Client as HttpClient;
+use Memed\Soluti\Http\Request;
+
+/**
+ * This class is responsible for handling session on Soluti's service.
+ */
+class Session
+{
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(HttpClient $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Creates a new session using given credentials.
+     */
+    public function create(Credentials $credentials): Token
+    {
+        $request = new Request(
+            'post',
+            'https://apicloudid.hom.vaultid.com.br/oauth',
+            [
+                'client_id' => $credentials->client()->id(),
+                'client_secret' => $credentials->client()->secret(),
+                'username' => $credentials->username(),
+                'password' => $credentials->password(),
+                'grant_type' => 'password',
+                'scope' => 'signature_session',
+                'lifetime' => $credentials->ttl(),
+            ]
+        );
+
+        return $this->parseResponse($this->client->json($request));
+    }
+
+    /**
+     * Retrieves a token instance with response of session request.
+     */
+    protected function parseResponse(Response $response): Token
+    {
+        $body = json_decode((string) $response->getBody(), true);
+
+        return new Token(
+            $body['access_token'],
+            $body['token_type'],
+            $body['expires_in'],
+            $body['scope']
+        );
+    }
+}

--- a/src/Memed/Soluti/Auth/Token.php
+++ b/src/Memed/Soluti/Auth/Token.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Auth;
+
+class Token
+{
+    /**
+     * @var string
+     */
+    protected $token;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var int
+     */
+    protected $expires_in;
+
+    /**
+     * @var string
+     */
+    protected $scope;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(
+        string $token,
+        string $type,
+        int $expires_in,
+        string $scope
+    ) {
+        $this->token = $token;
+        $this->type = $type;
+        $this->expires_in = $expires_in;
+        $this->scope = $scope;
+    }
+
+    /**
+     * Retrieves token string.
+     */
+    public function token(): string
+    {
+        return $this->token;
+    }
+
+    /**
+     * Retrieves type of token.
+     */
+    public function type(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Retrieves expires_in time.
+     */
+    public function expiresIn(): int
+    {
+        return $this->expires_in;
+    }
+
+    /**
+     * Retrieves scope of token.
+     */
+    public function scope(): string
+    {
+        return $this->scope;
+    }
+
+    /**
+     * Retrieves token as formatted string.
+     */
+    public function __toString(): string
+    {
+        $type = ucfirst($this->type());
+
+        return "{$type} {$this->token()}";
+    }
+}

--- a/src/Memed/Soluti/Auth/Token.php
+++ b/src/Memed/Soluti/Auth/Token.php
@@ -17,28 +17,12 @@ class Token implements AuthStrategy
     protected $type;
 
     /**
-     * @var int
-     */
-    protected $expires_in;
-
-    /**
-     * @var string
-     */
-    protected $scope;
-
-    /**
      * Constructor.
      */
-    public function __construct(
-        string $token,
-        string $type,
-        int $expires_in,
-        string $scope
-    ) {
+    public function __construct(string $token, string $type)
+    {
         $this->token = $token;
         $this->type = $type;
-        $this->expires_in = $expires_in;
-        $this->scope = $scope;
     }
 
     /**
@@ -55,22 +39,6 @@ class Token implements AuthStrategy
     public function type(): string
     {
         return $this->type;
-    }
-
-    /**
-     * Retrieves expires_in time.
-     */
-    public function expiresIn(): int
-    {
-        return $this->expires_in;
-    }
-
-    /**
-     * Retrieves scope of token.
-     */
-    public function scope(): string
-    {
-        return $this->scope;
     }
 
     /**

--- a/src/Memed/Soluti/Auth/Token.php
+++ b/src/Memed/Soluti/Auth/Token.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Memed\Soluti\Auth;
 
-class Token
+class Token implements AuthStrategy
 {
     /**
      * @var string

--- a/src/Memed/Soluti/Config.php
+++ b/src/Memed/Soluti/Config.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti;
+
+class Config
+{
+    /**
+     * @var array
+     */
+    protected $data = [];
+
+    /**
+     * Constructor.
+     */
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * Retrieves url of cess service.
+     */
+    public function cessUrl(): ?string
+    {
+        return $this->data['url_cess'];
+    }
+
+    /**
+     * Retrieves url of vault id service.
+     */
+    public function vaultIdUrl(): ?string
+    {
+        return $this->data['url_vaultid'];
+    }
+}

--- a/src/Memed/Soluti/Document.php
+++ b/src/Memed/Soluti/Document.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti;
+
+class Document
+{
+    /**
+     * @var string
+     */
+    protected $filename;
+
+    /**
+     * @var resource
+     */
+    protected $file;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(string $path)
+    {
+        $this->parseFile($path);
+    }
+
+    /**
+     * Retrieves filename.
+     */
+    public function filename(): string
+    {
+        return $this->filename;
+    }
+
+    /**
+     * Retrieves file.
+     */
+    public function file()
+    {
+        return $this->file;
+    }
+
+    /**
+     * Retrieves the content of given file path.
+     */
+    protected function parseFile(string $path): void
+    {
+        $this->filename = end(explode('/', $path));
+        $this->file = fopen($path, 'r');
+    }
+}

--- a/src/Memed/Soluti/Document.php
+++ b/src/Memed/Soluti/Document.php
@@ -45,7 +45,9 @@ class Document
      */
     protected function parseFile(string $path): void
     {
-        $this->filename = end(explode('/', $path));
+        $name = explode('/', $path);
+
+        $this->filename = end($name);
         $this->file = fopen($path, 'r');
     }
 }

--- a/src/Memed/Soluti/Http/Client.php
+++ b/src/Memed/Soluti/Http/Client.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Http;
+
+use BadMethodCallException;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * This class is responsible for abstracting common actions and informations
+ * which are used to interact with Soluti's web service.
+ */
+class Client
+{
+    protected const REQUEST_TYPE_JSON = 'json';
+    protected const REQUEST_TYPE_MULTIPART = 'multipart';
+
+    /**
+     * @var GuzzleClient
+     */
+    protected $guzzle;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(GuzzleClient $guzzle)
+    {
+        $this->guzzle = $guzzle;
+    }
+
+    /**
+     * Sends a request to guzzle using respective content-type and body options
+     * for JSON format.
+     */
+    public function json(Request $request): Response
+    {
+        return $this->send($request, static::REQUEST_TYPE_JSON);
+    }
+
+    /**
+     * Sends a request to guzzle using respective content-type and body options
+     * for Multipart format.
+     */
+    public function multipart(Request $request): Response
+    {
+        return $this->send($request, static::REQUEST_TYPE_MULTIPART);
+    }
+
+    /**
+     * Sends a request to guzzle using GET method.
+     */
+    public function get(Request $request, array $options = []): Response
+    {
+        return $this->guzzle->get(
+            $request->getUri(),
+            array_merge(
+                ['headers' => $request->getHeaders()],
+                $options
+            )
+        );
+    }
+
+    /**
+     * Sends a request to guzzle and save the response on the destination path
+     * given.
+     */
+    public function download(Request $request, string $destination): Response
+    {
+        return $this->get($request, ['save_to' => $destination]);
+    }
+
+    /**
+     * Triggers a request to guzzle.
+     */
+    private function send(Request $request, string $type): Response
+    {
+        return $this->guzzle->request(
+            $request->getMethod(),
+            $request->getUri(),
+            [
+                'headers' => $request->getHeaders(),
+                $type => $request->getData(),
+            ]
+        );
+    }
+}

--- a/src/Memed/Soluti/Http/Request.php
+++ b/src/Memed/Soluti/Http/Request.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Http;
+
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
+
+class Request extends GuzzleRequest
+{
+    protected const HEADER_DEFAULT = [
+        'Accept' => 'application/json',
+        'Cache-Control' => 'no-cache',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $data = [];
+
+    /**
+     * Constructor.
+     */
+    public function __construct(
+        string $method,
+        string $uri,
+        array $data = [],
+        array $headers = []
+    ) {
+        parent::__construct($method, $uri, array_merge(
+            static::HEADER_DEFAULT,
+            $headers
+        ));
+
+        $this->data = $data;
+    }
+
+    /**
+     * Retrieves request data.
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Memed/Soluti/Manager.php
+++ b/src/Memed/Soluti/Manager.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti;
+
+use Memed\Soluti\Auth\Session;
+use Memed\Soluti\Http\Client;
+use Memed\Soluti\Receiver\Downloader;
+use Memed\Soluti\Receiver\Receiver;
+use Memed\Soluti\Transmitter\Transmitter;
+
+class Manager
+{
+    /**
+     * Constructor.
+     */
+    public function __construct(
+        Config $config,
+        Client $client,
+        Transmitter $transmitter = null,
+        Receiver $receiver = null,
+        Downloader $downloader = null,
+        Session $session = null
+    ) {
+        $this->config = $config;
+        $this->client = $client;
+        $this->transmitter = $transmitter ?: new Transmitter($this);
+        $this->receiver = $receiver ?: new Receiver($this);
+        $this->downloader = $downloader ?: new Downloader($this);
+        $this->session = $session ?: new Session($this);
+    }
+
+    /**
+     * Retrieves client object.
+     */
+    public function client(): Client
+    {
+        return $this->client;
+    }
+
+    /**
+     * Retrieves transmitter object.
+     */
+    public function transmitter(): Transmitter
+    {
+        return $this->transmitter;
+    }
+
+    /**
+     * Retrieves receiver object.
+     */
+    public function receiver(): Receiver
+    {
+        return $this->receiver;
+    }
+
+    /**
+     * Retrieves downloader object.
+     */
+    public function downloader(): Downloader
+    {
+        return $this->downloader;
+    }
+
+    /**
+     * Retrieves session object.
+     */
+    public function session(): Session
+    {
+        return $this->session;
+    }
+
+    /**
+     * Retrieves cess uri plus given endpoint.
+     */
+    public function cessUrl(string $endpoint = ''): string
+    {
+        return $this->config->cessUrl().$endpoint;
+    }
+
+    /**
+     * Retrieves vaultid uri plus given endpoint.
+     */
+    public function vaultIdUrl(string $endpoint = ''): string
+    {
+        return $this->config->vaultIdUrl().$endpoint;
+    }
+}

--- a/src/Memed/Soluti/Manager.php
+++ b/src/Memed/Soluti/Manager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Memed\Soluti;
 
+use GuzzleHttp\Client as GuzzleClient;
 use Memed\Soluti\Auth\Session;
 use Memed\Soluti\Http\Client;
 use Memed\Soluti\Receiver\Downloader;
@@ -13,18 +14,48 @@ use Memed\Soluti\Transmitter\Transmitter;
 class Manager
 {
     /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * @var Transmitter
+     */
+    protected $transmitter;
+
+    /**
+     * @var Receiver
+     */
+    protected $receiver;
+
+    /**
+     * @var Downloader
+     */
+    protected $downloader;
+
+    /**
+     * @var Session
+     */
+    protected $session;
+
+    /**
      * Constructor.
      */
     public function __construct(
         Config $config,
-        Client $client,
+        Client $client = null,
         Transmitter $transmitter = null,
         Receiver $receiver = null,
         Downloader $downloader = null,
         Session $session = null
     ) {
         $this->config = $config;
-        $this->client = $client;
+        $this->client = $client ?: new Client(new GuzzleClient());
         $this->transmitter = $transmitter ?: new Transmitter($this);
         $this->receiver = $receiver ?: new Receiver($this);
         $this->downloader = $downloader ?: new Downloader($this);

--- a/src/Memed/Soluti/Receiver/Document.php
+++ b/src/Memed/Soluti/Receiver/Document.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Receiver;
+
+class Document
+{
+    public const STATUS_SIGNED = 'SIGNED';
+
+    /**
+     * @var status
+     */
+    protected $status;
+
+    /**
+     * @var string
+     */
+    protected $location;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(string $status, ?string $location)
+    {
+        $this->status = $status;
+        $this->location = $location;
+    }
+
+    /**
+     * Checks if document is still waiting to be signed.
+     */
+    public function isSigned(): bool
+    {
+        return $this->status === static::STATUS_SIGNED;
+    }
+
+    /**
+     * Retrieves file's location.
+     */
+    public function location(): string
+    {
+        return $this->location;
+    }
+
+    /**
+     * Retrieves an unique name for document using it's location.
+     */
+    public function name(string $extension = 'pdf'): string
+    {
+        $path = explode('/', $this->location());
+        $name = implode('_', array_slice($path, count($path) - 2));
+
+        return sprintf('%s.%s', $name, $extension);
+    }
+}

--- a/src/Memed/Soluti/Receiver/DocumentSet.php
+++ b/src/Memed/Soluti/Receiver/DocumentSet.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Receiver;
+
+use ArrayIterator;
+
+class DocumentSet extends ArrayIterator
+{
+    /**
+     * Checks if this set has at least one document unsigned.
+     */
+    public function isWaiting(): bool
+    {
+        foreach ($this as $document) {
+            if (false === $document->isSigned()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Memed/Soluti/Receiver/Downloader.php
+++ b/src/Memed/Soluti/Receiver/Downloader.php
@@ -4,23 +4,23 @@ declare(strict_types=1);
 
 namespace Memed\Soluti\Receiver;
 
-use Memed\Soluti\Http\Client;
 use Memed\Soluti\Http\Request;
+use Memed\Soluti\Manager;
 use Memed\Soluti\Receiver\DocumentSet;
 
 class Downloader
 {
     /**
-     * @var Client
+     * @var Manager
      */
-    protected $client;
+    protected $manager;
 
     /**
      * Constructor.
      */
-    public function __construct(Client $client)
+    public function __construct(Manager $manager)
     {
-        $this->client = $client;
+        $this->manager = $manager;
     }
 
     /**
@@ -32,7 +32,7 @@ class Downloader
         return array_map(function (Document $document) use ($destinationDir) {
             $destination = $destinationDir . $document->name();
 
-            $this->client->download(
+            $this->manager->client()->download(
                 new Request('get', $document->location()),
                 $destination
             );

--- a/src/Memed/Soluti/Receiver/Downloader.php
+++ b/src/Memed/Soluti/Receiver/Downloader.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Receiver;
+
+use Memed\Soluti\Http\Client;
+use Memed\Soluti\Http\Request;
+use Memed\Soluti\Receiver\DocumentSet;
+
+class Downloader
+{
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Downloads at destination directory all documents in the given document
+     * set.
+     */
+    public function download(DocumentSet $documentSet, string $destinationDir): array
+    {
+        return array_map(function (Document $document) use ($destinationDir) {
+            $destination = $destinationDir . $document->name();
+
+            $this->client->download(
+                new Request('get', $document->location()),
+                $destination
+            );
+
+            return $destination;
+        }, $documentSet->getArrayCopy());
+    }
+}

--- a/src/Memed/Soluti/Receiver/Receiver.php
+++ b/src/Memed/Soluti/Receiver/Receiver.php
@@ -35,7 +35,7 @@ class Receiver
             $documentSet = $this->parseReponse($this->request($token));
             $attemps++;
             sleep($delay);
-        } while ($documentSet->isWaiting() && $attemps <= $maxAttempts);
+        } while ($documentSet->isWaiting() && $attemps < $maxAttempts);
 
         return $documentSet;
     }

--- a/src/Memed/Soluti/Receiver/Receiver.php
+++ b/src/Memed/Soluti/Receiver/Receiver.php
@@ -63,7 +63,7 @@ class Receiver
         $body = json_decode((string) $response->getBody(), true);
 
         $documents = array_map(function (array $document) {
-            return new Document($document['status'], $document['result']);
+            return new Document($document['status'], $document['result'] ?? '');
         }, $body['documents']);
 
         return new DocumentSet($documents);

--- a/src/Memed/Soluti/Receiver/Receiver.php
+++ b/src/Memed/Soluti/Receiver/Receiver.php
@@ -48,7 +48,7 @@ class Receiver
         return $this->manager->client()->get(
             new Request(
                 'get',
-                'http://cess:8080/signature-service/'.(string) $token
+                $this->manager->cessUrl('/signature-service/'.(string) $token)
             )
         );
     }

--- a/src/Memed/Soluti/Receiver/Receiver.php
+++ b/src/Memed/Soluti/Receiver/Receiver.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Receiver;
+
+use GuzzleHttp\Psr7\Response;
+use Memed\Soluti\Http\Client;
+use Memed\Soluti\Http\Request;
+use Memed\Soluti\Transmitter\Token;
+
+class Receiver
+{
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Retrieves a set of parsed documents for given token transaction. It
+     * attempts to get these documents sometimes because signature service
+     * may have a delay to sign them.
+     */
+    public function getDocuments(Token $token, int $maxAttempts = 5, int $delay = 0): DocumentSet
+    {
+        do {
+            $documentSet = $this->parseReponse($this->request($token));
+            $attemps++;
+            sleep($delay);
+        } while ($documentSet->isWaiting() && $attemps <= $maxAttempts);
+
+        return $documentSet;
+    }
+
+    /**
+     * Requests status of signature transaction.
+     */
+    protected function request(Token $token): Response
+    {
+        return $this->client->get(
+            new Request(
+                'get',
+                'http://cess:8080/signature-service/'.(string) $token
+            )
+        );
+    }
+
+    /**
+     * Retrieves a set containing all documents in respective transaction.
+     */
+    protected function parseReponse(Response $response): DocumentSet
+    {
+        $body = json_decode((string) $response->getBody(), true);
+
+        $documents = array_map(function (array $document) {
+            return new Document($document['status'], $document['result']);
+        }, $body['documents']);
+
+        return new DocumentSet($documents);
+    }
+}

--- a/src/Memed/Soluti/Receiver/Receiver.php
+++ b/src/Memed/Soluti/Receiver/Receiver.php
@@ -5,23 +5,23 @@ declare(strict_types=1);
 namespace Memed\Soluti\Receiver;
 
 use GuzzleHttp\Psr7\Response;
-use Memed\Soluti\Http\Client;
 use Memed\Soluti\Http\Request;
+use Memed\Soluti\Manager;
 use Memed\Soluti\Transmitter\Token;
 
 class Receiver
 {
     /**
-     * @var Client
+     * @var Manager
      */
-    protected $client;
+    protected $manager;
 
     /**
      * Constructor.
      */
-    public function __construct(Client $client)
+    public function __construct(Manager $manager)
     {
-        $this->client = $client;
+        $this->manager = $manager;
     }
 
     /**
@@ -45,7 +45,7 @@ class Receiver
      */
     protected function request(Token $token): Response
     {
-        return $this->client->get(
+        return $this->manager->client()->get(
             new Request(
                 'get',
                 'http://cess:8080/signature-service/'.(string) $token

--- a/src/Memed/Soluti/Receiver/Receiver.php
+++ b/src/Memed/Soluti/Receiver/Receiver.php
@@ -31,11 +31,13 @@ class Receiver
      */
     public function getDocuments(Token $token, int $maxAttempts = 5, int $delay = 1): DocumentSet
     {
+        $attempts = 0;
+
         do {
             $documentSet = $this->parseReponse($this->request($token));
-            $attemps++;
+            $attempts++;
             sleep($delay);
-        } while ($documentSet->isWaiting() && $attemps < $maxAttempts);
+        } while ($documentSet->isWaiting() && $attempts < $maxAttempts);
 
         return $documentSet;
     }

--- a/src/Memed/Soluti/Receiver/Receiver.php
+++ b/src/Memed/Soluti/Receiver/Receiver.php
@@ -29,7 +29,7 @@ class Receiver
      * attempts to get these documents sometimes because signature service
      * may have a delay to sign them.
      */
-    public function getDocuments(Token $token, int $maxAttempts = 5, int $delay = 0): DocumentSet
+    public function getDocuments(Token $token, int $maxAttempts = 5, int $delay = 1): DocumentSet
     {
         do {
             $documentSet = $this->parseReponse($this->request($token));

--- a/src/Memed/Soluti/Signer.php
+++ b/src/Memed/Soluti/Signer.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti;
+
+use Memed\Soluti\Auth\AuthStrategy;
+use Memed\Soluti\Auth\Credentials;
+use Memed\Soluti\Auth\Session;
+use Memed\Soluti\Auth\Token;
+use Memed\Soluti\Receiver\DocumentSet;
+use Memed\Soluti\Receiver\Downloader;
+use Memed\Soluti\Receiver\Receiver;
+use Memed\Soluti\Transmitter\Transmitter;
+
+class Signer
+{
+    /**
+     * @var Manager
+     */
+    protected $manager;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(Manager $manager)
+    {
+        $this->manager = $manager;
+    }
+
+    /**
+     * Sends given document object to be signed in Soluti service using given
+     * strategy.
+     *
+     * @see Memed\Soluti\Auth\AuthStrategy
+     */
+    public function sign(
+        Document $document,
+        AuthStrategy $token,
+        string $destinationPath
+    ): array {
+        if ($token instanceof Credentials) {
+            $token = $this->manager->session()->create($token);
+        }
+
+        $transactionToken = $this->manager
+            ->transmitter()
+            ->transmit($document, $token);
+
+        $documents = $this->manager
+            ->receiver()
+            ->getDocuments($transactionToken);
+
+        return $this->manager
+            ->downloader()
+            ->download($documents, $destinationPath);
+    }
+}

--- a/src/Memed/Soluti/Transmitter/Token.php
+++ b/src/Memed/Soluti/Transmitter/Token.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Transmitter;
+
+class Token
+{
+    /**
+     * @var string
+     */
+    protected $token;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(string $token)
+    {
+        $this->token = $token;
+    }
+
+    /**
+     * Retrieves token.
+     */
+    public function token(): string
+    {
+        return $this->token;
+    }
+
+    /**
+     * Retrieves token object as string.
+     */
+    public function __toString(): string
+    {
+        return $this->token();
+    }
+}

--- a/src/Memed/Soluti/Transmitter/Transmitter.php
+++ b/src/Memed/Soluti/Transmitter/Transmitter.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Transmitter;
+
+use GuzzleHttp\Psr7\Response;
+use Memed\Soluti\Auth\Token as AuthToken;
+use Memed\Soluti\Document;
+use Memed\Soluti\Http\Client;
+use Memed\Soluti\Http\Request;
+
+class Transmitter
+{
+    /**
+     * Constructor.
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Uploads a file to be signed.
+     */
+    public function transmit(Document $document, AuthToken $authToken): Token
+    {
+        $transactionToken = $this->start($authToken);
+
+        $this->client->multipart(new Request(
+            'post',
+            "http://cess:8080/file-transfer/{$transactionToken}/eot",
+            [
+                [
+                    'name' => 'document[0]',
+                    'contents' => $document->file(),
+                    'filename' => $document->filename(),
+                ],
+            ]
+        ));
+
+        return $transactionToken;
+    }
+
+    /**
+     * Starts a new signature transaction for a single document.
+     */
+    protected function start(AuthToken $token)
+    {
+        return $this->parseReponse($this->client->json(
+            new Request(
+                'post',
+                'http://cess:8080/signature-service',
+                [
+                    'certificate_alias' => '',
+                    'type' => 'PDFSignature',
+                    'hash_algorithm' => 'SHA256',
+                    'auto_fix_document' => true,
+                    'documents_source' => 'UPLOAD_REFERENCE',
+                ],
+                [
+                    'Authorization' => (string) $token,
+                ]
+            )
+        ));
+    }
+
+    /**
+     * Retrieves a transaction token.
+     */
+    protected function parseReponse(Response $response): Token
+    {
+        $body = json_decode((string) $response->getBody(), true);
+
+        return new Token($body['tcn']);
+    }
+}

--- a/src/Memed/Soluti/Transmitter/Transmitter.php
+++ b/src/Memed/Soluti/Transmitter/Transmitter.php
@@ -34,7 +34,7 @@ class Transmitter
 
         $this->manager->client()->multipart(new Request(
             'post',
-            "http://cess:8080/file-transfer/{$transactionToken}/eot",
+            $this->manager->cessUrl("/file-transfer/{$transactionToken}/eot"),
             [
                 [
                     'name' => 'document[0]',
@@ -55,7 +55,7 @@ class Transmitter
         return $this->parseReponse($this->manager->client()->json(
             new Request(
                 'post',
-                'http://cess:8080/signature-service',
+                $this->manager->cessUrl('/signature-service'),
                 [
                     'certificate_alias' => '',
                     'type' => 'PDFSignature',

--- a/src/Memed/Soluti/Transmitter/Transmitter.php
+++ b/src/Memed/Soluti/Transmitter/Transmitter.php
@@ -7,17 +7,22 @@ namespace Memed\Soluti\Transmitter;
 use GuzzleHttp\Psr7\Response;
 use Memed\Soluti\Auth\Token as AuthToken;
 use Memed\Soluti\Document;
-use Memed\Soluti\Http\Client;
 use Memed\Soluti\Http\Request;
+use Memed\Soluti\Manager;
 
 class Transmitter
 {
     /**
+     * @var Manager
+     */
+    protected $manager;
+
+    /**
      * Constructor.
      */
-    public function __construct(Client $client)
+    public function __construct(Manager $manager)
     {
-        $this->client = $client;
+        $this->manager = $manager;
     }
 
     /**
@@ -27,7 +32,7 @@ class Transmitter
     {
         $transactionToken = $this->start($authToken);
 
-        $this->client->multipart(new Request(
+        $this->manager->client()->multipart(new Request(
             'post',
             "http://cess:8080/file-transfer/{$transactionToken}/eot",
             [
@@ -47,7 +52,7 @@ class Transmitter
      */
     protected function start(AuthToken $token)
     {
-        return $this->parseReponse($this->client->json(
+        return $this->parseReponse($this->manager->client()->json(
             new Request(
                 'post',
                 'http://cess:8080/signature-service',

--- a/tests/Memed/Soluti/Auth/SessionTest.php
+++ b/tests/Memed/Soluti/Auth/SessionTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Memed\Soluti\Auth;
 
 use GuzzleHttp\Psr7\Response;
+use Memed\Soluti\Config;
 use Memed\Soluti\Http\Client as HttpClient;
 use Memed\Soluti\Http\Request;
+use Memed\Soluti\Manager;
 use Memed\Soluti\TestCase;
 use Mockery as m;
 
@@ -39,7 +41,8 @@ class SessionTest extends TestCase
         ]);
 
         $client = m::mock(HttpClient::class);
-        $session = new Session($client);
+        $manager = new Manager(m::mock(Config::class), $client);
+        $session = new Session($manager);
         $response = m::mock(Response::class);
 
         $client->shouldReceive('json')

--- a/tests/Memed/Soluti/Auth/SessionTest.php
+++ b/tests/Memed/Soluti/Auth/SessionTest.php
@@ -16,6 +16,7 @@ class SessionTest extends TestCase
 {
     public function testCreateShouldStartANewSessionAndGeneratAnAuthToken()
     {
+        $vaultIdUrl = 'http://vaultid';
         $credentials = new Credentials(
             new Client('12345', 'client-secret'),
             'username',
@@ -41,7 +42,10 @@ class SessionTest extends TestCase
         ]);
 
         $client = m::mock(HttpClient::class);
-        $manager = new Manager(m::mock(Config::class), $client);
+        $manager = new Manager(
+            new Config(['url_vaultid' => $vaultIdUrl]),
+            $client
+        );
         $session = new Session($manager);
         $response = m::mock(Response::class);
 
@@ -49,7 +53,7 @@ class SessionTest extends TestCase
             ->with(m::on(function (Request $request) use ($requestBody) {
                 return (
                     $request->getMethod() === 'POST' &&
-                    (string) $request->getUri() === 'https://apicloudid.hom.vaultid.com.br/oauth' &&
+                    (string) $request->getUri() === 'http://vaultid/oauth' &&
                     $request->getData() === $requestBody
                 );
             }))

--- a/tests/Memed/Soluti/Auth/SessionTest.php
+++ b/tests/Memed/Soluti/Auth/SessionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Auth;
+
+use GuzzleHttp\Psr7\Response;
+use Memed\Soluti\Http\Client as HttpClient;
+use Memed\Soluti\Http\Request;
+use Memed\Soluti\TestCase;
+use Mockery as m;
+
+class SessionTest extends TestCase
+{
+    public function testCreateShouldStartANewSessionAndGeneratAnAuthToken()
+    {
+        $credentials = new Credentials(
+            new Client('12345', 'client-secret'),
+            'username',
+            'password',
+            60
+        );
+
+        $requestBody = [
+            'client_id' => $credentials->client()->id(),
+            'client_secret' => $credentials->client()->secret(),
+            'username' => $credentials->username(),
+            'password' => $credentials->password(),
+            'grant_type' => 'password',
+            'scope' => 'signature_session',
+            'lifetime' => $credentials->ttl(),
+        ];
+
+        $body = json_encode([
+            'access_token' => 'some-token',
+            'token_type' => 'some-type',
+            'expires_in' => 30,
+            'scope' => 'some-scope',
+        ]);
+
+        $client = m::mock(HttpClient::class);
+        $session = new Session($client);
+        $response = m::mock(Response::class);
+
+        $client->shouldReceive('json')
+            ->with(m::on(function (Request $request) use ($requestBody) {
+                return (
+                    $request->getMethod() === 'POST' &&
+                    (string) $request->getUri() === 'https://apicloudid.hom.vaultid.com.br/oauth' &&
+                    $request->getData() === $requestBody
+                );
+            }))
+            ->once()
+            ->andReturn($response);
+
+        $response->shouldReceive('getBody')
+            ->once()
+            ->andReturn($body);
+
+        $expected = new Token(
+            'some-token',
+            'some-type',
+            30,
+            'some-scope'
+        );
+
+        $this->assertEquals($expected, $session->create($credentials));
+    }
+}

--- a/tests/Memed/Soluti/Auth/TokenTest.php
+++ b/tests/Memed/Soluti/Auth/TokenTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Memed\Soluti\Auth;
 
-use PHPUnit\Framework\TestCase as TestCase;
+use Memed\Soluti\TestCase;
 
 class TokenTest extends TestCase
 {

--- a/tests/Memed/Soluti/Auth/TokenTest.php
+++ b/tests/Memed/Soluti/Auth/TokenTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Auth;
+
+use PHPUnit\Framework\TestCase as TestCase;
+
+class TokenTest extends TestCase
+{
+    public function testTokenCastingToStringShouldRetrieveToken()
+    {
+        $token = new Token('some token', 'some-type', 0, 'some-scope');
+
+        $this->assertEquals('Some-type some token', (string) $token);
+    }
+}

--- a/tests/Memed/Soluti/ConfigTest.php
+++ b/tests/Memed/Soluti/ConfigTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti;
+
+use Memed\Soluti\TestCase;
+
+class ConfigTest extends TestCase
+{
+    public function testCessUrlShouldRetrieveStringProperly()
+    {
+        $config = new Config(['url_cess' => 'some-cess-url']);
+
+        $this->assertEquals('some-cess-url', $config->cessUrl());
+    }
+
+    public function testVaultIdUrlShouldRetrieveStringProperly()
+    {
+        $config = new Config(['url_vaultid' => 'some-vaultid-url']);
+
+        $this->assertEquals('some-vaultid-url', $config->vaultIdUrl());
+    }
+}

--- a/tests/Memed/Soluti/DocumentTest.php
+++ b/tests/Memed/Soluti/DocumentTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti;
+
+class DocumentTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    protected $filepath;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp(): void
+    {
+        $this->filepath = __DIR__.'/fixtures/valid-file-to-sign.txt';
+    }
+
+    public function testFilenameShouldRetrieveNameProperly()
+    {
+        $document = new Document($this->filepath);
+
+        $this->assertEquals('valid-file-to-sign.txt', $document->filename());
+    }
+
+    public function testFileShouldRetrieveAFileStreaming()
+    {
+        $document = new Document($this->filepath);
+
+        $this->assertIsResource($document->file());
+    }
+}

--- a/tests/Memed/Soluti/Http/ClientTest.php
+++ b/tests/Memed/Soluti/Http/ClientTest.php
@@ -7,7 +7,7 @@ namespace Memed\Soluti\Http;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Psr7\Response;
 use Mockery as m;
-use PHPUnit\Framework\TestCase as TestCase;
+use Memed\Soluti\TestCase;
 
 class ClientTest extends TestCase
 {

--- a/tests/Memed/Soluti/Http/ClientTest.php
+++ b/tests/Memed/Soluti/Http/ClientTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Http;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response;
+use Mockery as m;
+use PHPUnit\Framework\TestCase as TestCase;
+
+class ClientTest extends TestCase
+{
+    public function testGetShouldSendAGetRequestToGuzzleUsingNoOptions()
+    {
+        $guzzle = m::mock(GuzzleClient::class);
+        $client = new Client($guzzle);
+        $response = m::mock(Response::class);
+
+        $request = new Request('get', 'some-uri');
+
+        $guzzle->shouldReceive('get')
+            ->with($request->getUri(), ['headers' => $request->getHeaders()])
+            ->once()
+            ->andReturn($response);
+
+        $this->assertEquals($response, $client->get($request));
+    }
+
+    public function testGetShouldSendAGetRequestToGuzzleMergingOptions()
+    {
+        $guzzle = m::mock(GuzzleClient::class);
+        $client = new Client($guzzle);
+        $response = m::mock(Response::class);
+        $options = ['custom' => 'option'];
+
+        $request = new Request('get', 'some-uri');
+
+        $guzzle->shouldReceive('get')
+            ->with($request->getUri(), [
+                'headers' => $request->getHeaders(),
+                'custom' => 'option',
+            ])
+            ->once()
+            ->andReturn($response);
+
+        $this->assertEquals($response, $client->get($request, $options));
+    }
+
+    public function testDownloadShouldSendAGetRequestToGuzzleUsingSaveTo()
+    {
+        $guzzle = m::mock(GuzzleClient::class);
+        $client = new Client($guzzle);
+        $response = m::mock(Response::class);
+        $destination = 'some/directory';
+
+        $request = new Request('get', 'some-uri');
+
+        $guzzle->shouldReceive('get')
+            ->with($request->getUri(), [
+                'headers' => $request->getHeaders(),
+                'save_to' => $destination,
+            ])
+            ->once()
+            ->andReturn($response);
+
+        $this->assertEquals(
+            $response,
+            $client->download($request, $destination)
+        );
+    }
+
+    public function testJsonShouldSendARequestToGuzzleWithCorrectBody()
+    {
+        $guzzle = m::mock(GuzzleClient::class);
+        $client = new Client($guzzle);
+        $response = m::mock(Response::class);
+        $body = [
+            'some' => 'body',
+            'json' => 'format',
+        ];
+
+        $request = new Request('post', 'some-uri', $body);
+
+        $guzzle->shouldReceive('request')
+            ->with(
+                'POST',
+                $request->getUri(),
+                [
+                    'headers' => $request->getHeaders(),
+                    'json' => $body,
+                ]
+            )
+            ->once()
+            ->andReturn($response);
+
+        $this->assertEquals($response, $client->json($request));
+    }
+
+    public function testMultipartShouldSendARequestToGuzzleWithCorrectBody()
+    {
+        $guzzle = m::mock(GuzzleClient::class);
+        $client = new Client($guzzle);
+        $response = m::mock(Response::class);
+        $body = [
+            'some' => 'body',
+            'files' => 'to upload',
+        ];
+
+        $request = new Request('post', 'some-uri', $body);
+
+        $guzzle->shouldReceive('request')
+            ->with(
+                'POST',
+                $request->getUri(),
+                [
+                    'headers' => $request->getHeaders(),
+                    'multipart' => $body,
+                ]
+            )
+            ->once()
+            ->andReturn($response);
+
+        $this->assertEquals($response, $client->multipart($request));
+    }
+}

--- a/tests/Memed/Soluti/Http/RequestTest.php
+++ b/tests/Memed/Soluti/Http/RequestTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Memed\Soluti\Http;
 
-use PHPUnit\Framework\TestCase as TestCase;
+use Memed\Soluti\TestCase;
 
 class RequestTest extends TestCase
 {

--- a/tests/Memed/Soluti/Http/RequestTest.php
+++ b/tests/Memed/Soluti/Http/RequestTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Http;
+
+use PHPUnit\Framework\TestCase as TestCase;
+
+class RequestTest extends TestCase
+{
+    public function testRequestConstructorShouldUseDefaultHeaders()
+    {
+        $request = new Request('method', 'some-uri');
+
+        $expected = [
+            'Accept' => ['application/json'],
+            'Cache-Control' => ['no-cache'],
+        ];
+
+        $this->assertEquals($expected, $request->getHeaders());
+    }
+
+    public function testRequestConstructorShouldMergeHeaders()
+    {
+        $headers = [
+            'Additional' => 'Header',
+        ];
+
+        $request = new Request('method', 'some-uri', [], $headers);
+
+        $expected = [
+            'Accept' => ['application/json'],
+            'Cache-Control' => ['no-cache'],
+            'Additional' => ['Header'],
+        ];
+
+        $this->assertEquals($expected, $request->getHeaders());
+    }
+}

--- a/tests/Memed/Soluti/ManagerTest.php
+++ b/tests/Memed/Soluti/ManagerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti;
+
+use Memed\Soluti\Http\Client;
+use Memed\Soluti\TestCase;
+use Mockery as m;
+
+class ManagerTest extends TestCase
+{
+    public function testCessUrlShouldRetrieveUrlFromConfig()
+    {
+        $config = m::mock(Config::class);
+
+        $config->shouldReceive('cessUrl')
+            ->once()
+            ->andReturn('http://cess.url/');
+
+        $manager = new Manager($config, m::mock(Client::class));
+
+        $this->assertEquals('http://cess.url/', $manager->cessUrl());
+    }
+
+    public function testCessUrlShouldRetrieveUrlFromConfigConcatenatingEndpoint()
+    {
+        $config = m::mock(Config::class);
+
+        $config->shouldReceive('cessUrl')
+            ->once()
+            ->andReturn('http://cess.url/');
+
+        $manager = new Manager($config, m::mock(Client::class));
+
+        $this->assertEquals(
+            'http://cess.url/end/point',
+            $manager->cessUrl('end/point')
+        );
+    }
+
+    public function testVaultIdUrlShouldRetrieveUrlFromConfig()
+    {
+        $config = m::mock(Config::class);
+
+        $config->shouldReceive('vaultIdUrl')
+            ->once()
+            ->andReturn('http://vaultid.url/');
+
+        $manager = new Manager($config, m::mock(Client::class));
+
+        $this->assertEquals('http://vaultid.url/', $manager->vaultIdUrl());
+    }
+
+    public function testVaultIdUrlShouldRetrieveUrlFromConfigConcatenatingEndpoint()
+    {
+        $config = m::mock(Config::class);
+
+        $config->shouldReceive('vaultIdUrl')
+            ->once()
+            ->andReturn('http://vaultid.url/');
+
+        $manager = new Manager($config, m::mock(Client::class));
+
+        $this->assertEquals(
+            'http://vaultid.url/end/point',
+            $manager->vaultIdUrl('end/point')
+        );
+    }
+}

--- a/tests/Memed/Soluti/Receiver/DocumentSetTest.php
+++ b/tests/Memed/Soluti/Receiver/DocumentSetTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Receiver;
+
+use PHPUnit\Framework\TestCase as TestCase;
+
+class DocumentSetTest extends TestCase
+{
+    /**
+     * @dataProvider getDocuments
+     */
+    public function testIsWatingShouldCheckIfDocumentsIsNotSignedYet(bool $expected, array $documents)
+    {
+        $documentSet = new DocumentSet($documents);
+        $this->assertEquals($expected, $documentSet->isWaiting());
+    }
+
+    public function getDocuments()
+    {
+        yield 'single document not signed' => [
+            'expected' => true,
+            'documents' => [
+                new Document('WAITING', null),
+            ],
+        ];
+
+        yield 'multiple documents not signed' => [
+            'expected' => true,
+            'documents' => [
+                new Document('WAITING', null),
+                new Document('WAITING', null),
+                new Document('WAITING', null),
+                new Document('WAITING', null),
+            ],
+        ];
+
+        yield 'multiple signed documents and one not signed' => [
+            'expected' => true,
+            'documents' => [
+                new Document('SIGNED', null),
+                new Document('SIGNED', null),
+                new Document('WAITING', null),
+                new Document('SIGNED', null),
+            ],
+        ];
+
+        yield 'single document signed' => [
+            'expected' => false,
+            'documents' => [
+                new Document('SIGNED', null),
+            ],
+        ];
+
+        yield 'multiple documents signed' => [
+            'expected' => false,
+            'documents' => [
+                new Document('SIGNED', null),
+                new Document('SIGNED', null),
+                new Document('SIGNED', null),
+                new Document('SIGNED', null),
+            ],
+        ];
+    }
+}

--- a/tests/Memed/Soluti/Receiver/DocumentSetTest.php
+++ b/tests/Memed/Soluti/Receiver/DocumentSetTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Memed\Soluti\Receiver;
 
-use PHPUnit\Framework\TestCase as TestCase;
+use Memed\Soluti\TestCase;
 
 class DocumentSetTest extends TestCase
 {

--- a/tests/Memed/Soluti/Receiver/DocumentTest.php
+++ b/tests/Memed/Soluti/Receiver/DocumentTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Receiver;
+
+use PHPUnit\Framework\TestCase as TestCase;
+
+class DocumentTest extends TestCase
+{
+    public function testIsSignedShouldReturnTrueIfStatusCorrespondsToSigned()
+    {
+        $document = new Document('SIGNED', null);
+
+        $this->assertTrue($document->isSigned());
+    }
+
+    public function testIsSignedShouldReturnFalseIfStatusIsNotCorrespondingToSigned()
+    {
+        $document = new Document('WAITING', null);
+
+        $this->assertFalse($document->isSigned());
+    }
+
+    public function testNameShouldParseDocumentNameUsingItsLocationAndUseDefaultExtension()
+    {
+        $location = 'http://soluti/absolute/path/to/document/0';
+
+        $document = new Document('SIGNED', $location);
+
+        $this->assertEquals('document_0.pdf', $document->name());
+    }
+
+    public function testNameShouldParseDocumentNameUsingItsLocationAndUseCustomExtension()
+    {
+        $location = 'http://soluti/absolute/path/to/document/0';
+        $extension = 'custom';
+
+        $document = new Document('SIGNED', $location);
+
+        $this->assertEquals('document_0.custom', $document->name($extension));
+    }
+}

--- a/tests/Memed/Soluti/Receiver/DocumentTest.php
+++ b/tests/Memed/Soluti/Receiver/DocumentTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Memed\Soluti\Receiver;
 
-use PHPUnit\Framework\TestCase as TestCase;
+use Memed\Soluti\TestCase;
 
 class DocumentTest extends TestCase
 {

--- a/tests/Memed/Soluti/Receiver/DownloaderTest.php
+++ b/tests/Memed/Soluti/Receiver/DownloaderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Receiver;
+
+use Memed\Soluti\Http\Client;
+use Memed\Soluti\Http\Request;
+use Memed\Soluti\Receiver\Document;
+use Memed\Soluti\Receiver\DocumentSet;
+use Mockery as m;
+use PHPUnit\Framework\TestCase as TestCase;
+
+class DownloaderTest extends TestCase
+{
+    public function testDownloadShouldProcessAllDocumentsInADocumentSet()
+    {
+        $client = m::mock(Client::class);
+        $downloader = new Downloader($client);
+        $destination = 'destination/dir/';
+
+        $documentSet = new DocumentSet([
+            new Document('SIGNED', 'location/document/0'),
+            new Document('SIGNED', 'location/document/1'),
+        ]);
+
+        $client->shouldReceive('download')
+            ->with(
+                m::on(function (Request $request) {
+                    return (string) $request->getUri() === 'location/document/0';
+                }),
+                'destination/dir/document_0.pdf'
+            )
+            ->once();
+
+        $client->shouldReceive('download')
+            ->with(
+                m::on(function (Request $request) {
+                    return (string) $request->getUri() === 'location/document/1';
+                }),
+                'destination/dir/document_1.pdf'
+            )
+            ->once();
+
+        $expected = [
+            'destination/dir/document_0.pdf',
+            'destination/dir/document_1.pdf',
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $downloader->download($documentSet, $destination)
+        );
+    }
+}

--- a/tests/Memed/Soluti/Receiver/DownloaderTest.php
+++ b/tests/Memed/Soluti/Receiver/DownloaderTest.php
@@ -9,7 +9,7 @@ use Memed\Soluti\Http\Request;
 use Memed\Soluti\Receiver\Document;
 use Memed\Soluti\Receiver\DocumentSet;
 use Mockery as m;
-use PHPUnit\Framework\TestCase as TestCase;
+use Memed\Soluti\TestCase;
 
 class DownloaderTest extends TestCase
 {

--- a/tests/Memed/Soluti/Receiver/DownloaderTest.php
+++ b/tests/Memed/Soluti/Receiver/DownloaderTest.php
@@ -4,19 +4,22 @@ declare(strict_types=1);
 
 namespace Memed\Soluti\Receiver;
 
+use Memed\Soluti\Config;
 use Memed\Soluti\Http\Client;
 use Memed\Soluti\Http\Request;
+use Memed\Soluti\Manager;
 use Memed\Soluti\Receiver\Document;
 use Memed\Soluti\Receiver\DocumentSet;
-use Mockery as m;
 use Memed\Soluti\TestCase;
+use Mockery as m;
 
 class DownloaderTest extends TestCase
 {
     public function testDownloadShouldProcessAllDocumentsInADocumentSet()
     {
         $client = m::mock(Client::class);
-        $downloader = new Downloader($client);
+        $manager = new Manager(m::mock(Config::class), $client);
+        $downloader = new Downloader($manager);
         $destination = 'destination/dir/';
 
         $documentSet = new DocumentSet([

--- a/tests/Memed/Soluti/Receiver/ReceiverTest.php
+++ b/tests/Memed/Soluti/Receiver/ReceiverTest.php
@@ -9,7 +9,7 @@ use Memed\Soluti\Http\Client;
 use Memed\Soluti\Http\Request;
 use Memed\Soluti\Transmitter\Token;
 use Mockery as m;
-use PHPUnit\Framework\TestCase as TestCase;
+use Memed\Soluti\TestCase;
 
 class ReceiverTest extends TestCase
 {

--- a/tests/Memed/Soluti/Receiver/ReceiverTest.php
+++ b/tests/Memed/Soluti/Receiver/ReceiverTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Receiver;
+
+use GuzzleHttp\Psr7\Response;
+use Memed\Soluti\Http\Client;
+use Memed\Soluti\Http\Request;
+use Memed\Soluti\Transmitter\Token;
+use Mockery as m;
+use PHPUnit\Framework\TestCase as TestCase;
+
+class ReceiverTest extends TestCase
+{
+    public function testGetDocumentsShouldReturnSignedDocumentSetOnTheFirstAttempt()
+    {
+        $client = m::mock(Client::class);
+        $receiver = new Receiver($client);
+        $token = new Token('some-token', 'some-alias');
+        $response = m::mock(Response::class);
+
+        $body = json_encode([
+            'documents' => [
+                ['status' => 'SIGNED', 'result' => 'location/document/0'],
+                ['status' => 'SIGNED', 'result' => 'location/document/1'],
+            ],
+        ]);
+
+        $client->shouldReceive('get')
+            ->with(m::on(function (Request $request) {
+                return (string) $request->getUri() === 'http://cess:8080/signature-service/some-token';
+            }))
+            ->once()
+            ->andReturn($response);
+
+        $response->shouldReceive('getBody')
+            ->once()
+            ->andReturn($body);
+
+        $expected = new DocumentSet([
+            new Document('SIGNED', 'location/document/0'),
+            new Document('SIGNED', 'location/document/1'),
+        ]);
+
+        $this->assertEquals($expected, $receiver->getDocuments($token));
+    }
+
+    public function testGetDocumentsShouldReturnSignedDocumentSetOnTheLastAttempt()
+    {
+        $client = m::mock(Client::class);
+        $receiver = new Receiver($client);
+        $token = new Token('some-token', 'some-alias');
+        $waitingResponse = m::mock(Response::class);
+        $successResponse = m::mock(Response::class);
+
+        $waitingBody = json_encode([
+            'documents' => [
+                ['status' => 'WAITING'],
+                ['status' => 'WAITING'],
+            ],
+        ]);
+
+        $successBody = json_encode([
+            'documents' => [
+                ['status' => 'SIGNED', 'result' => 'location/document/0'],
+                ['status' => 'SIGNED', 'result' => 'location/document/1'],
+            ],
+        ]);
+
+        $client->shouldReceive('get')
+            ->with(m::on(function (Request $request) {
+                return (string) $request->getUri() === 'http://cess:8080/signature-service/some-token';
+            }))
+            ->times(5)
+            ->andReturn(
+                $waitingResponse,
+                $waitingResponse,
+                $waitingResponse,
+                $waitingResponse,
+                $successResponse
+            );
+
+        $waitingResponse->shouldReceive('getBody')
+            ->times(4)
+            ->andReturn($waitingBody);
+
+        $successResponse->shouldReceive('getBody')
+            ->once()
+            ->andReturn($successBody);
+
+        $expected = new DocumentSet([
+            new Document('SIGNED', 'location/document/0'),
+            new Document('SIGNED', 'location/document/1'),
+        ]);
+
+        $this->assertEquals($expected, $receiver->getDocuments($token, 5, 0));
+    }
+
+    public function testGetDocumentsShouldReturnWaitingDocumentSetAfterAllAttempts()
+    {
+        $client = m::mock(Client::class);
+        $receiver = new Receiver($client);
+        $token = new Token('some-token', 'some-alias');
+        $response = m::mock(Response::class);
+
+        $body = json_encode([
+            'documents' => [
+                ['status' => 'WAITING'],
+                ['status' => 'WAITING'],
+            ],
+        ]);
+
+        $client->shouldReceive('get')
+            ->with(m::on(function (Request $request) {
+                return (string) $request->getUri() === 'http://cess:8080/signature-service/some-token';
+            }))
+            ->times(3)
+            ->andReturn($response);
+
+        $response->shouldReceive('getBody')
+            ->times(3)
+            ->andReturn($body);
+
+        $expected = new DocumentSet([
+            new Document('WAITING', null),
+            new Document('WAITING', null),
+        ]);
+
+        $this->assertEquals($expected, $receiver->getDocuments($token, 3, 0));
+    }
+}

--- a/tests/Memed/Soluti/Receiver/ReceiverTest.php
+++ b/tests/Memed/Soluti/Receiver/ReceiverTest.php
@@ -5,18 +5,21 @@ declare(strict_types=1);
 namespace Memed\Soluti\Receiver;
 
 use GuzzleHttp\Psr7\Response;
+use Memed\Soluti\Config;
 use Memed\Soluti\Http\Client;
 use Memed\Soluti\Http\Request;
+use Memed\Soluti\Manager;
+use Memed\Soluti\TestCase;
 use Memed\Soluti\Transmitter\Token;
 use Mockery as m;
-use Memed\Soluti\TestCase;
 
 class ReceiverTest extends TestCase
 {
     public function testGetDocumentsShouldReturnSignedDocumentSetOnTheFirstAttempt()
     {
         $client = m::mock(Client::class);
-        $receiver = new Receiver($client);
+        $manager = new Manager(m::mock(Config::class), $client);
+        $receiver = new Receiver($manager);
         $token = new Token('some-token', 'some-alias');
         $response = m::mock(Response::class);
 
@@ -49,7 +52,8 @@ class ReceiverTest extends TestCase
     public function testGetDocumentsShouldReturnSignedDocumentSetOnTheLastAttempt()
     {
         $client = m::mock(Client::class);
-        $receiver = new Receiver($client);
+        $manager = new Manager(m::mock(Config::class), $client);
+        $receiver = new Receiver($manager);
         $token = new Token('some-token', 'some-alias');
         $waitingResponse = m::mock(Response::class);
         $successResponse = m::mock(Response::class);
@@ -100,7 +104,8 @@ class ReceiverTest extends TestCase
     public function testGetDocumentsShouldReturnWaitingDocumentSetAfterAllAttempts()
     {
         $client = m::mock(Client::class);
-        $receiver = new Receiver($client);
+        $manager = new Manager(m::mock(Config::class), $client);
+        $receiver = new Receiver($manager);
         $token = new Token('some-token', 'some-alias');
         $response = m::mock(Response::class);
 

--- a/tests/Memed/Soluti/Receiver/ReceiverTest.php
+++ b/tests/Memed/Soluti/Receiver/ReceiverTest.php
@@ -17,8 +17,9 @@ class ReceiverTest extends TestCase
 {
     public function testGetDocumentsShouldReturnSignedDocumentSetOnTheFirstAttempt()
     {
+        $cessUrl = 'http://cess';
         $client = m::mock(Client::class);
-        $manager = new Manager(m::mock(Config::class), $client);
+        $manager = new Manager(new Config(['url_cess' => $cessUrl]), $client);
         $receiver = new Receiver($manager);
         $token = new Token('some-token', 'some-alias');
         $response = m::mock(Response::class);
@@ -32,7 +33,7 @@ class ReceiverTest extends TestCase
 
         $client->shouldReceive('get')
             ->with(m::on(function (Request $request) {
-                return (string) $request->getUri() === 'http://cess:8080/signature-service/some-token';
+                return (string) $request->getUri() === 'http://cess/signature-service/some-token';
             }))
             ->once()
             ->andReturn($response);
@@ -46,13 +47,14 @@ class ReceiverTest extends TestCase
             new Document('SIGNED', 'location/document/1'),
         ]);
 
-        $this->assertEquals($expected, $receiver->getDocuments($token));
+        $this->assertEquals($expected, $receiver->getDocuments($token, 5, 0));
     }
 
     public function testGetDocumentsShouldReturnSignedDocumentSetOnTheLastAttempt()
     {
+        $cessUrl = 'http://cess';
         $client = m::mock(Client::class);
-        $manager = new Manager(m::mock(Config::class), $client);
+        $manager = new Manager(new Config(['url_cess' => $cessUrl]), $client);
         $receiver = new Receiver($manager);
         $token = new Token('some-token', 'some-alias');
         $waitingResponse = m::mock(Response::class);
@@ -74,7 +76,7 @@ class ReceiverTest extends TestCase
 
         $client->shouldReceive('get')
             ->with(m::on(function (Request $request) {
-                return (string) $request->getUri() === 'http://cess:8080/signature-service/some-token';
+                return (string) $request->getUri() === 'http://cess/signature-service/some-token';
             }))
             ->times(5)
             ->andReturn(
@@ -103,8 +105,9 @@ class ReceiverTest extends TestCase
 
     public function testGetDocumentsShouldReturnWaitingDocumentSetAfterAllAttempts()
     {
+        $cessUrl = 'http://cess';
         $client = m::mock(Client::class);
-        $manager = new Manager(m::mock(Config::class), $client);
+        $manager = new Manager(new Config(['url_cess' => $cessUrl]), $client);
         $receiver = new Receiver($manager);
         $token = new Token('some-token', 'some-alias');
         $response = m::mock(Response::class);
@@ -118,7 +121,7 @@ class ReceiverTest extends TestCase
 
         $client->shouldReceive('get')
             ->with(m::on(function (Request $request) {
-                return (string) $request->getUri() === 'http://cess:8080/signature-service/some-token';
+                return (string) $request->getUri() === 'http://cess/signature-service/some-token';
             }))
             ->times(3)
             ->andReturn($response);

--- a/tests/Memed/Soluti/SignerTest.php
+++ b/tests/Memed/Soluti/SignerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti;
+
+use Memed\Soluti\Auth\Credentials;
+use Memed\Soluti\Auth\Session;
+use Memed\Soluti\Auth\Token as AuthToken;
+use Memed\Soluti\Http\Client;
+use Memed\Soluti\Receiver\DocumentSet;
+use Memed\Soluti\Receiver\Downloader;
+use Memed\Soluti\Receiver\Receiver;
+use Memed\Soluti\TestCase;
+use Memed\Soluti\Transmitter\Token as TransactionToken;
+use Memed\Soluti\Transmitter\Transmitter;
+use Mockery as m;
+
+class SignerTest extends TestCase
+{
+    public function testSignShouldRetrieveFilesUsingAuthTokenStrategy()
+    {
+        $transmitter = m::mock(Transmitter::class);
+        $receiver = m::mock(Receiver::class);
+        $downloader = m::mock(Downloader::class);
+        $manager = new Manager(
+            m::mock(Config::class),
+            m::mock(Client::class),
+            $transmitter,
+            $receiver,
+            $downloader
+        );
+
+        $document = m::mock(Document::class);
+        $authToken = m::mock(AuthToken::class);
+        $destination = 'some/destination/directory/';
+
+        $transactionToken = m::mock(TransactionToken::class);
+        $documentSet = m::mock(DocumentSet::class);
+        $files = [
+            'some/destination/directory/file_1.pdf',
+            'some/destination/directory/file_2.pdf',
+            'some/destination/directory/file_3.pdf',
+        ];
+
+        $transmitter->shouldReceive('transmit')
+            ->with($document, $authToken)
+            ->once()
+            ->andReturn($transactionToken);
+
+        $receiver->shouldReceive('getDocuments')
+            ->with($transactionToken)
+            ->once()
+            ->andReturn($documentSet);
+
+        $downloader->shouldReceive('download')
+            ->with($documentSet, $destination)
+            ->once()
+            ->andReturn($files);
+
+        $this->assertEquals(
+            $files,
+            (new Signer($manager))->sign($document, $authToken, $destination)
+        );
+    }
+
+    public function testSignShouldRetrieveFilesUsingCredentialsStrategy()
+    {
+        $transmitter = m::mock(Transmitter::class);
+        $receiver = m::mock(Receiver::class);
+        $downloader = m::mock(Downloader::class);
+        $session = m::mock(Session::class);
+        $manager = new Manager(
+            m::mock(Config::class),
+            m::mock(Client::class),
+            $transmitter,
+            $receiver,
+            $downloader,
+            $session
+        );
+
+        $document = m::mock(Document::class);
+        $authToken = m::mock(AuthToken::class);
+        $destination = 'some/destination/directory/';
+
+        $credentials = m::mock(Credentials::class);
+        $transactionToken = m::mock(TransactionToken::class);
+        $documentSet = m::mock(DocumentSet::class);
+        $files = [
+            'some/destination/directory/file_1.pdf',
+            'some/destination/directory/file_2.pdf',
+            'some/destination/directory/file_3.pdf',
+        ];
+
+        $session->shouldReceive('create')
+            ->with($credentials)
+            ->once()
+            ->andReturn($authToken);
+
+        $transmitter->shouldReceive('transmit')
+            ->with($document, $authToken)
+            ->once()
+            ->andReturn($transactionToken);
+
+        $receiver->shouldReceive('getDocuments')
+            ->with($transactionToken)
+            ->once()
+            ->andReturn($documentSet);
+
+        $downloader->shouldReceive('download')
+            ->with($documentSet, $destination)
+            ->once()
+            ->andReturn($files);
+
+        $this->assertEquals(
+            $files,
+            (new Signer($manager))->sign($document, $credentials, $destination)
+        );
+    }
+}

--- a/tests/Memed/Soluti/TestCase.php
+++ b/tests/Memed/Soluti/TestCase.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function teardown(): void
+    {
+        parent::teardown();
+        m::close();
+    }
+}

--- a/tests/Memed/Soluti/Transmitter/TokenTest.php
+++ b/tests/Memed/Soluti/Transmitter/TokenTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Memed\Soluti\Transmitter;
 
-use PHPUnit\Framework\TestCase as TestCase;
+use Memed\Soluti\TestCase;
 
 class TokenTest extends TestCase
 {

--- a/tests/Memed/Soluti/Transmitter/TokenTest.php
+++ b/tests/Memed/Soluti/Transmitter/TokenTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Transmitter;
+
+use PHPUnit\Framework\TestCase as TestCase;
+
+class TokenTest extends TestCase
+{
+    public function testToStringShouldRetrieveTokenAsString()
+    {
+        $token = new Token('some-token');
+
+        $this->assertEquals('some-token', (string) $token);
+    }
+}

--- a/tests/Memed/Soluti/Transmitter/TransmitterTest.php
+++ b/tests/Memed/Soluti/Transmitter/TransmitterTest.php
@@ -6,19 +6,22 @@ namespace Memed\Soluti\Transmitter;
 
 use GuzzleHttp\Psr7\Response;
 use Memed\Soluti\Auth\Token as AuthToken;
+use Memed\Soluti\Config;
 use Memed\Soluti\Document;
 use Memed\Soluti\Http\Client;
 use Memed\Soluti\Http\Request;
+use Memed\Soluti\Manager;
+use Memed\Soluti\TestCase;
 use Memed\Soluti\Transmitter\Token as TransactionToken;
 use Mockery as m;
-use Memed\Soluti\TestCase;
 
 class TransmitterTest extends TestCase
 {
     public function testTransmitShouldSendAFileUsingClient()
     {
         $client = m::mock(Client::class);
-        $transmitter = new Transmitter($client);
+        $manager = new Manager(m::mock(Config::class), $client);
+        $transmitter = new Transmitter($manager);
         $authToken = new AuthToken('auth-token', 'bearer', 30, 'scope');
         $transactionToken = new TransactionToken('transaction-token');
         $transactionResponse = m::mock(Response::class);

--- a/tests/Memed/Soluti/Transmitter/TransmitterTest.php
+++ b/tests/Memed/Soluti/Transmitter/TransmitterTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Memed\Soluti\Transmitter;
+
+use GuzzleHttp\Psr7\Response;
+use Memed\Soluti\Auth\Token as AuthToken;
+use Memed\Soluti\Document;
+use Memed\Soluti\Http\Client;
+use Memed\Soluti\Http\Request;
+use Memed\Soluti\Transmitter\Token as TransactionToken;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class TransmitterTest extends TestCase
+{
+    public function testTransmitShouldSendAFileUsingClient()
+    {
+        $client = m::mock(Client::class);
+        $transmitter = new Transmitter($client);
+        $authToken = new AuthToken('auth-token', 'bearer', 30, 'scope');
+        $transactionToken = new TransactionToken('transaction-token');
+        $transactionResponse = m::mock(Response::class);
+
+        $authData = [
+            'certificate_alias' => '',
+            'type' => 'PDFSignature',
+            'hash_algorithm' => 'SHA256',
+            'auto_fix_document' => true,
+            'documents_source' => 'UPLOAD_REFERENCE',
+        ];
+
+        $uploadData = [[
+            'name' => 'document[0]',
+            'contents' => 'some-file',
+            'filename' => 'somefile.name',
+        ]];
+
+        $document = m::mock(Document::class);
+
+        $document->shouldReceive('file')
+            ->once()
+            ->andReturn('some-file');
+
+        $document->shouldReceive('filename')
+            ->once()
+            ->andReturn('somefile.name');
+
+        $client->shouldReceive('json')
+            ->with(m::on(function (Request $request) use ($authData, $authToken) {
+                return (
+                    $request->getMethod() === 'POST' &&
+                    (string) $request->getUri() === 'http://cess:8080/signature-service' &&
+                    $request->getData() === $authData &&
+                    $request->getHeader('Authorization') === [(string) $authToken]
+                );
+            }))
+            ->once()
+            ->andReturn($transactionResponse);
+
+        $transactionResponse->shouldReceive('getBody')
+            ->once()
+            ->andReturn(json_encode([
+                'tcn' => (string) $transactionToken,
+            ]));
+
+        $client->shouldReceive('multipart')
+            ->with(m::on(function (Request $request) use ($transactionToken, $uploadData) {
+                return (
+                    $request->getMethod() === 'POST' &&
+                    "http://cess:8080/file-transfer/{$transactionToken}/eot" &&
+                    $request->getData() === $uploadData
+                );
+            }))
+            ->once();
+
+        $this->assertEquals(
+            $transactionToken,
+            $transmitter->transmit($document, $authToken)
+        );
+    }
+}

--- a/tests/Memed/Soluti/Transmitter/TransmitterTest.php
+++ b/tests/Memed/Soluti/Transmitter/TransmitterTest.php
@@ -19,8 +19,9 @@ class TransmitterTest extends TestCase
 {
     public function testTransmitShouldSendAFileUsingClient()
     {
+        $cessUrl = 'http://cess';
         $client = m::mock(Client::class);
-        $manager = new Manager(m::mock(Config::class), $client);
+        $manager = new Manager(new Config(['url_cess' => $cessUrl]), $client);
         $transmitter = new Transmitter($manager);
         $authToken = new AuthToken('auth-token', 'bearer', 30, 'scope');
         $transactionToken = new TransactionToken('transaction-token');
@@ -54,7 +55,7 @@ class TransmitterTest extends TestCase
             ->with(m::on(function (Request $request) use ($authData, $authToken) {
                 return (
                     $request->getMethod() === 'POST' &&
-                    (string) $request->getUri() === 'http://cess:8080/signature-service' &&
+                    (string) $request->getUri() === 'http://cess/signature-service' &&
                     $request->getData() === $authData &&
                     $request->getHeader('Authorization') === [(string) $authToken]
                 );
@@ -72,7 +73,7 @@ class TransmitterTest extends TestCase
             ->with(m::on(function (Request $request) use ($transactionToken, $uploadData) {
                 return (
                     $request->getMethod() === 'POST' &&
-                    "http://cess:8080/file-transfer/{$transactionToken}/eot" &&
+                    "http://cess/file-transfer/{$transactionToken}/eot" &&
                     $request->getData() === $uploadData
                 );
             }))

--- a/tests/Memed/Soluti/Transmitter/TransmitterTest.php
+++ b/tests/Memed/Soluti/Transmitter/TransmitterTest.php
@@ -11,7 +11,7 @@ use Memed\Soluti\Http\Client;
 use Memed\Soluti\Http\Request;
 use Memed\Soluti\Transmitter\Token as TransactionToken;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
+use Memed\Soluti\TestCase;
 
 class TransmitterTest extends TestCase
 {

--- a/tests/Memed/Soluti/fixtures/valid-file-to-sign.txt
+++ b/tests/Memed/Soluti/fixtures/valid-file-to-sign.txt
@@ -1,0 +1,1 @@
+Just a valid file to sign.


### PR DESCRIPTION
# Soluti PHP sdk

Its a simple SDK for PHP language that abstract Soluti's digital signature service. In the first moment is possible to sign PDF documents authenticating using _OAuth_ or _Basic Credentials_

## Installation

```bash
composer require "memeddev/soluti-sdk-php=*"
```

## Basic Usage

```php
use Memed\Soluti\Auth\Client;
use Memed\Soluti\Auth\Credentials;
use Memed\Soluti\Auth\Token;
use Memed\Soluti\Config;
use Memed\Soluti\Document;
use Memed\Soluti\Manager;
use Memed\Soluti\Signer;
use GuzzleHttp\Client as GuzzleClient;

// -----------------------
// Authentication strategy
// -----------------------

// Using Credentials
$token = new Credentials(
    new Client('CLIENT_ID', 'CLIENT_SECRET'),
    'USERNAME',
    'PASSWORD',
    60 // How much longer token will be acceptable after authentication (in seconds)
);

// Using OAuth token
$token = new Token('some-secret-oauth-token', 'bearer');

// -----------------------
// Document signature
// -----------------------
 
// Defines base URL's
$config = new Config([
    'url_cess' => 'http://cess:8080',
    'url_vaultid' => 'https://apicloudid.hom.vaultid.com.br/oauth',
]);

// Initializes signer service
$manager = new Manager($config, new Client(new GuzzleClient());
$signer = new Signer($manager);

// Creates a document instance using file which you want to sign.
$document = new Document(__DIR__.'/file_to_sign.pdf');

// Defines directory to save signed documents.
$destinationDir = '/some/directory';

// Signs document
$files = $signer->sign($document, $token, $destinationDir);

// Result
// array(1) {
//   [0] =>
//   string(32) "/some/directory/signed_file.pdf"
// }
```
