### PR TITLE
10367 Add authentication for every valid cloud

### DIFF
--- a/src/Memed/Soluti/Auth/CloudAuthentication.php
+++ b/src/Memed/Soluti/Auth/CloudAuthentication.php
@@ -87,15 +87,17 @@ class CloudAuthentication
     /**
      * @return Cloud
      */
-    public function authenticatedCloud(): ?Cloud
+    public function authenticatedClouds(): array
     {
+        $authenticatedClouds = [];
+
         foreach ($this->clouds() as $cloud) {
             if ($cloud->discoveredOauthUser() && $cloud->discoveredOauthUser()->isValid()) {
-                return $cloud;
+                $authenticatedClouds[] = $cloud;
             }
         }
 
-        return null;
+        return $authenticatedClouds;
     }
 
     /**

--- a/src/Memed/Soluti/Auth/Session.php
+++ b/src/Memed/Soluti/Auth/Session.php
@@ -107,8 +107,6 @@ class Session
 
             if ($authenticatedCloud->discoveredOauthUser()->isValid()) {
                 $payload['clouds'][$cloudName] = $authenticatedCloud;
-
-                return CloudAuthentication::create($payload);
             }
         }
 

--- a/tests/Memed/Soluti/Auth/CloudAuthenticationTest.php
+++ b/tests/Memed/Soluti/Auth/CloudAuthenticationTest.php
@@ -22,7 +22,7 @@ class CloudAuthenticationTest extends TestCase
                 '12345',
                 'birdid-secret',
                 '12345',
-                'vaultid-secret',
+                'vaultid-secret'
             ),
             'username',
             'password',

--- a/tests/Memed/Soluti/Auth/SessionTest.php
+++ b/tests/Memed/Soluti/Auth/SessionTest.php
@@ -32,7 +32,7 @@ class SessionTest extends TestCase
                 '12345',
                 'birdid-secret',
                 '12345',
-                'vaultid-secret',
+                'vaultid-secret'
             ),
             'username',
             'password',
@@ -41,7 +41,7 @@ class SessionTest extends TestCase
 
         $this->userToken = new Token(
             'some-token',
-            'some-type',
+            'some-type'
         );
 
         $this->applicationToken = new ApplicationToken(

--- a/tests/Memed/Soluti/SignerTest.php
+++ b/tests/Memed/Soluti/SignerTest.php
@@ -77,7 +77,7 @@ class SignerTest extends TestCase
                 '12345',
                 'birdid-secret',
                 '12345',
-                'vaultid-secret',
+                'vaultid-secret'
             ),
             'username',
             'password',
@@ -99,8 +99,15 @@ class SignerTest extends TestCase
         $applicationToken = new ApplicationToken(
             'some-token',
             'some-type',
-            CloudAuthentication::CLOUD_NAME_BIRD_ID,
+            CloudAuthentication::CLOUD_NAME_BIRD_ID
         );
+
+        $failCloudMock = m::mock(Cloud::class, [
+            CloudAuthentication::CLOUD_NAME_VAULT_ID,
+            'http://vaultid',
+            $applicationToken,
+        ])
+            ->makePartial();
 
         $cloudMock = m::mock(Cloud::class, [
             CloudAuthentication::CLOUD_NAME_BIRD_ID,
@@ -110,8 +117,8 @@ class SignerTest extends TestCase
             ->makePartial();
 
         $cloudAuthentication = m::mock(CloudAuthentication::class);
-        $cloudAuthentication->shouldReceive('authenticatedCloud')
-            ->andReturn($cloudMock);
+        $cloudAuthentication->shouldReceive('authenticatedClouds')
+            ->andReturn([$failCloudMock, $cloudMock]);
 
         $session->shouldReceive('cloudAuthentication')
             ->with($credentials)
@@ -121,7 +128,7 @@ class SignerTest extends TestCase
         $document = m::mock(Document::class);
         $authToken = new AuthToken(
             'some-token',
-            'some-type',
+            'some-type'
         );
         $destination = 'some/destination/directory/';
 
@@ -132,6 +139,11 @@ class SignerTest extends TestCase
             'some/destination/directory/file_2.pdf',
             'some/destination/directory/file_3.pdf',
         ];
+
+        $session->shouldReceive('create')
+            ->with($credentials, $failCloudMock)
+            ->once()
+            ->andThrow('\Exception', 'message', 123456789);
 
         $session->shouldReceive('create')
             ->with($credentials, $cloudMock)


### PR DESCRIPTION
When a user has certificates on more than one cloud, we need to try authentication on every cloud, until success.