### PR TITLE
10536 Added verification for document status ERROR

### DIFF
--- a/src/Memed/Soluti/Receiver/Document.php
+++ b/src/Memed/Soluti/Receiver/Document.php
@@ -6,6 +6,7 @@ namespace Memed\Soluti\Receiver;
 
 class Document
 {
+    public const STATUS_ERROR = 'ERROR';
     public const STATUS_SIGNED = 'SIGNED';
 
     /**
@@ -25,6 +26,14 @@ class Document
     {
         $this->status = $status;
         $this->location = $location;
+    }
+
+    /**
+     * Checks if an error was find when processing the document.
+     */
+    public function hasError(): bool
+    {
+        return $this->status === static::STATUS_ERROR;
     }
 
     /**

--- a/src/Memed/Soluti/Receiver/DocumentSet.php
+++ b/src/Memed/Soluti/Receiver/DocumentSet.php
@@ -9,6 +9,20 @@ use ArrayIterator;
 class DocumentSet extends ArrayIterator
 {
     /**
+     * Checks if this set has at least one document with error.
+     */
+    public function hasError(): bool
+    {
+        foreach ($this as $document) {
+            if ($document->hasError()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Checks if this set has at least one document unsigned.
      */
     public function isWaiting(): bool

--- a/src/Memed/Soluti/Receiver/Receiver.php
+++ b/src/Memed/Soluti/Receiver/Receiver.php
@@ -39,6 +39,10 @@ class Receiver
             $documentSet = $this->parseReponse($this->request($token));
             $attempts++;
             sleep($delay);
+
+            if ($documentSet->hasError()) {
+                throw new \Exception('Erro ao baixar o PDF assinado.');
+            }
         } while ($documentSet->isWaiting() && $attempts < $maxAttempts);
 
         if ($documentSet->isWaiting() && $attempts === $maxAttempts) {


### PR DESCRIPTION
Sometimes, CESS is returning STATUS=ERROR on the download request. To avoid waiting max attempts, a verification was added.